### PR TITLE
Handle empty select elements in SQLi scanner

### DIFF
--- a/newsqli.py
+++ b/newsqli.py
@@ -49,7 +49,12 @@ def form_details(form):
     for select_tag in form.find_all("select"):
         input_name = select_tag.attrs.get("name")
         options = [option.attrs.get("value", "") for option in select_tag.find_all("option")]
-        inputs.append({"type": "select", "name": input_name, "value": options[0]})  # Default to first option
+        # Some select elements may not contain any options. In such cases the
+        # previous implementation attempted to access the first element of the
+        # list which raised an ``IndexError``.  Default to an empty string when
+        # no options are available to avoid crashing during form parsing.
+        default_value = options[0] if options else ""
+        inputs.append({"type": "select", "name": input_name, "value": default_value})
 
     detailsOfForm['action'] = action
     detailsOfForm['method'] = method


### PR DESCRIPTION
## Summary
- Avoid IndexError when parsing form `<select>` elements without options

## Testing
- `python -m py_compile newsqli.py`
- `python - <<'PY'
from bs4 import BeautifulSoup
from newsqli import form_details
html = '''<form action="/test" method="post"><select name="sel"></select></form>'''
form = BeautifulSoup(html, "html.parser").find('form')
print(form_details(form))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68999ea3f7b88329a1ef7fa94eca1575